### PR TITLE
IPv6-support

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -6,16 +6,28 @@ Description: Pseudonymize IP addresses (remove last 2 segments/bytes).
 Version: 1.0
 Author: Ubicoo
 Author URI: http://www.ubicoo.com
-*/
+ */
 
- 
+
 yourls_add_filter( 'get_IP', 'ubicoo_pseudonymize_IP' );
- 
-function ubicoo_pseudonymize_IP( $value ) {
-	$segments = explode(".", $value);
-	$segments[2] = 0;
-	$segments[3] = 0;
-	$pseudo_IP = implode(".", $segments);
-	return $pseudo_IP;
+
+function ubicoo_pseudonymize_IP( $ip ) {
+    if(filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6)) {
+        $segments = explode(":", $ip);
+        $segments[count($segments)-1] = 0;
+
+        $pseudo_IP = implode(":", $segments);
+
+        # FIXME: What about: ::ffff:127.0.0.1? It's a valid v6 as well!
+    } elseif(filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4)) {
+        $segments = explode(".", $ip);
+        $segments[3] = 0;
+
+        $pseudo_IP = implode(".", $segments);
+    } else {
+        $pseudo_IP = $ip;
+    }
+
+    return $pseudo_IP;
 }
 


### PR DESCRIPTION
- Added IPv6 support (incomplete)
- Only set last touple of IPv4 to null. This is fine even for german
  concerns.
